### PR TITLE
Add example donation links to `info.xml`

### DIFF
--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Download schema
-        run: wget https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd
+        run: wget https://raw.githubusercontent.com/nextcloud/appstore/fix/donation-type/nextcloudappstore/api/v1/release/info.xsd
 
       - name: Lint info.xml
         uses: ChristophWurst/xmllint-action@36f2a302f84f8c83fceea0b9c59e1eb4a616d3c1 # v1.2

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,6 +11,9 @@
 	<namespace>AppTemplate</namespace>
 	<category>customization</category>
 	<bugs>https://example.com/bugs</bugs>
+	<donation title="Donate to the developers with PayPal" type="paypal">https://paypal.com/example</donation>
+	<donation type="stripe">https://stripe.com/example</donation>
+	<donation>https://other.service.com/example</donation>
 	<dependencies>
 		<nextcloud min-version="29" max-version="30"/>
 	</dependencies>


### PR DESCRIPTION
This is just for testing that validation works for the donation attribute for now, but in the future, it would be nice if users could be able to specify the links themselves from the app skeleton generator form in the app store. This PR (or rather, just 5eea581ee589926051afd68a7ee96daeefd0c0b1) could then be merged if that happens.