### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,9 +1643,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.21.0.tgz",
-      "integrity": "sha512-at06uh2JJkn8dV3Yzyoag2z1g6omad8MZ8yKWE+9ZAGP+kaysbnI5q3lB7KXu8SVRtX3Rex8/oal0jgsbb6Spg==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.22.0.tgz",
+      "integrity": "sha512-6smeLUVLl8lqh+ia9j+m3nk9fnjra/YNgNO8RI1He8LRuojB9ZQtIy3kGcqIN1BOi6fx9qLiBEkobazWzMmiSw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -1683,6 +1683,7 @@
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
+        "tabbable": "^6.2.0",
         "tributejs": "^5.1.3",
         "unified": "^11.0.1",
         "unist-builder": "^4.0.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 7 of the total 16 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/vite-config](#user-content-\@nextcloud\/vite-config)
* [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
* [@vue/language-core](#user-content-\@vue\/language-core)
* [vite-plugin-dts](#user-content-vite-plugin-dts)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue-tsc](#user-content-vue-tsc)
## Fixed vulnerabilities

### @nextcloud/vite-config <a href="#user-content-\@nextcloud\/vite-config" id="\@nextcloud\/vite-config">#</a>
* Caused by vulnerable dependency:
  * [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
  * [vite-plugin-dts](#user-content-vite-plugin-dts)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vite-config`

### @vitejs/plugin-vue2 <a href="#user-content-\@vitejs\/plugin-vue2" id="\@vitejs\/plugin-vue2">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@vitejs/plugin-vue2`

### @vue/language-core <a href="#user-content-\@vue\/language-core" id="\@vue\/language-core">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=2.0.28
* Package usage:
  * `node_modules/@vue/language-core`

### vite-plugin-dts <a href="#user-content-vite-plugin-dts" id="vite-plugin-dts">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
  * [vue-tsc](#user-content-vue-tsc)
* Affected versions: 3.0.0-beta.1 - 4.0.0-beta.2
* Package usage:
  * `node_modules/vite-plugin-dts`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`