### PR TITLE
Replace `ubuntu-latest-low` with `ubuntu-latest` in GitHub Workflows

### DIFF
--- a/.github/workflows/block-unconventional-commits.yml
+++ b/.github/workflows/block-unconventional-commits.yml
@@ -23,7 +23,7 @@ jobs:
   block-unconventional-commits:
     name: Block unconventional commits
 
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     name: Block fixup and squash commits
 
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     steps:
       - name: Run check

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -87,7 +87,7 @@ jobs:
   summary:
     permissions:
       contents: none
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: [changes, lint]
 
     if: always()

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   xml-linters:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     name: info.xml lint
     steps:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     outputs:
       php-versions: ${{ steps.versions.outputs.php-versions }}
     steps:
@@ -63,7 +63,7 @@ jobs:
   summary:
     permissions:
       contents: none
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: php-lint
 
     if: always()

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -94,7 +94,7 @@ jobs:
   summary:
     permissions:
       contents: none
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: [changes, build]
 
     if: always()

--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     outputs:
       ocp-matrix: ${{ steps.versions.outputs.ocp-matrix }}
     steps:
@@ -75,7 +75,7 @@ jobs:
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github
 
   summary:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: static-analysis
 
     if: always()

--- a/.github/workflows/update-nextcloud-ocp-approve-merge.yml
+++ b/.github/workflows/update-nextcloud-ocp-approve-merge.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   auto-approve-merge:
     if: github.actor == 'nextcloud-command'
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     permissions:
       # for hmarr/auto-approve-action to approve PRs
       pull-requests: write


### PR DESCRIPTION
The `ubuntu-latest-low` runner doesn't seem to exist in default GitHub environments. At least I can't find it on https://github.com/actions/runner-images. This causes the workflows to be stuck indefinitely waiting for a runner.
If I'm mistaken and the `ubuntu-latest-low` runners are available somewhere, I'd be very glad for a pointer :D