### PR TITLE
chore: update license

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<summary>An example summary</summary>
 	<description>An example description</description>
 	<version>1.0.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author mail="example@example.com" homepage="https://example.com">Example</author>
 	<namespace>AppTemplate</namespace>
 	<category>customization</category>

--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "An example summary",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {


### PR DESCRIPTION
Now that the `min-version` is 31 thanks to #174, I think we can safely switch to the [new license tag](https://nextcloudappstore.readthedocs.io/en/latest/developer.html#app-metadata) now since we don't support v30 or below anymore.

Although, I've also been wondering whether or not we should change the license to MIT or something else for this project. Technically, any apps based on the template app as it is now are supposed to be licensed under the AGPL as well, which might not be what every developer wants. What do you think?