### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6f810d951d6a012d6365b9b7e60a95ba68fb5ca1"
+                "reference": "5ac47a5321b5621d1bac795acb0c4268fc0cb3e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f810d951d6a012d6365b9b7e60a95ba68fb5ca1",
-                "reference": "6f810d951d6a012d6365b9b7e60a95ba68fb5ca1",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5ac47a5321b5621d1bac795acb0c4268fc0cb3e8",
+                "reference": "5ac47a5321b5621d1bac795acb0c4268fc0cb3e8",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2026-04-23T01:28:54+00:00"
+            "time": "2026-08-11T00:53:03+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency